### PR TITLE
Add recursive clone to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sudo apt-get update
 sudo apt-get -y install git libwebp-dev libssl-dev zlib1g-dev
 
 # Clone repository
-git clone https://github.com/tronbyt/tronberry.git
+git clone --recurse-submodules https://github.com/tronbyt/tronberry.git
 
 # Build
 cd tronberry


### PR DESCRIPTION
This makes sure we also clone the rpi-led-matrix repo and websocket repo when cloning this repo to build locally