### PR TITLE
feat: Add client info to WebSocket connection and versioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,16 @@ jobs:
     - name: Install dependencies
       run: sudo ./.github/scripts/setup-linux.sh
     - name: Build
-      run: make
+      run: |
+        VERSION=""
+        if [[ $GITHUB_REF == refs/tags/v* ]]; then
+          VERSION=${GITHUB_REF#refs/tags/v}
+        fi
+        if [ -n "$VERSION" ]; then
+          make FIRMWARE_VERSION="$VERSION"
+        else
+          make
+        fi
     - name: Archive artifacts
       uses: actions/upload-artifact@v5
       with:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ INCLUDES := -I/usr/local/include -I/opt/homebrew/include -Ilibs
 LIBPATHS := -L/usr/local/lib -L/opt/homebrew/lib
 LDFLAGS := $(LIBPATHS) -lwebp -lwebpdemux -lssl -lcrypto
 CFLAGS=-W -Wall -Wextra -Wno-unused-parameter -O3 -fPIC -march=native
-CXXFLAGS :=$(CFLAGS) -fno-exceptions -std=c++23
+FIRMWARE_VERSION ?= dev
+CXXFLAGS :=$(CFLAGS) -fno-exceptions -std=c++23 -DFIRMWARE_VERSION='"$(FIRMWARE_VERSION)"'
 TARGET := tronberry
 SRCS := main.cc startup.cc
 RGB_LIB_DISTRIBUTION=libs/rpi-rgb-led-matrix

--- a/main.cc
+++ b/main.cc
@@ -3,6 +3,8 @@
 
 #include <chrono>
 #include <deque>
+#include <fstream>
+#include <format>
 #include <iostream>
 #include <queue>
 #include <string>
@@ -14,6 +16,13 @@
 #include "led-matrix.h"
 #include "startup.h"
 
+#ifndef FIRMWARE_VERSION
+#define FIRMWARE_VERSION "dev"
+#endif
+
+#define FIRMWARE_TYPE "Tronberry"
+#define PROTOCOL_VERSION 1
+
 using namespace rgb_matrix;
 
 static std::atomic<bool> running(true);
@@ -21,6 +30,24 @@ static std::atomic<int> brightness(INITIAL_BRIGHTNESS);
 static bool verbose = false;
 static std::condition_variable queue_not_full;
 static std::condition_variable queue_not_empty;
+
+static std::string get_mac_address() {
+  for (const char *iface_name : {"eth0", "wlan0"}) {
+    std::ifstream iface(std::format("/sys/class/net/{}/address", iface_name));
+    if (iface.is_open()) {
+      std::string mac;
+      if (std::getline(iface, mac)) {
+        // Trim whitespace from end
+        size_t endpos = mac.find_last_not_of(" \t\n\r");
+        if (std::string::npos != endpos) {
+          mac = mac.substr(0, endpos + 1);
+        }
+        return mac;
+      }
+    }
+  }
+  return "xx:xx:xx:xx:xx:xx";  // fallback
+}
 
 static void Log(const std::string &message) {
   if (!verbose) {
@@ -245,7 +272,19 @@ int main(int argc, char *argv[]) {
           if (!running) {
             return;
           }
-          if (msg->type == ix::WebSocketMessageType::Message) {
+          if (msg->type == ix::WebSocketMessageType::Open) {
+            Log("WebSocket connection established");
+            const nlohmann::json client_info_msg = {
+                {"client_info", {
+                    {"firmware_version", FIRMWARE_VERSION},
+                    {"firmware_type", FIRMWARE_TYPE},
+                    {"protocol_version", PROTOCOL_VERSION},
+                    {"mac", get_mac_address()}
+                }}
+            };
+            Log("Sending client info: " + client_info_msg.dump());
+            ws_client.send(client_info_msg.dump());
+          } else if (msg->type == ix::WebSocketMessageType::Message) {
             if (msg->binary) {
               Log("Received image of size " +
                   std::to_string(msg->str.size()) + " bytes");


### PR DESCRIPTION
This commit introduces the following features:

- **Client Information on WebSocket Connection:** The Tronberry client now sends a `client_info` message to the WebSocket server upon successful connection. This message includes:
    - `firmware_version`: Dynamically supplied from git tags during CI builds or defaults to "dev" for local builds.
    - `firmware_type`: Defined as a preprocessor macro `FIRMWARE_TYPE`.
    - `protocol_version`: Defined as a preprocessor macro `PROTOCOL_VERSION`.
    - `mac`: Retrieved using a new `get_mac_address()` function.
- **Dynamic Firmware Versioning:** The `Makefile` and `.github/workflows/build.yml` have been updated to allow the `FIRMWARE_VERSION` to be set at compile-time based on git tags. This ensures that release builds are correctly versioned.
- **MAC Address Retrieval:** A new `get_mac_address()` function has been added to `main.cc` to retrieve the device's MAC address from system files.

This change enhances the server's ability to identify and track connected Tronberry devices, improving overall system management and debugging.