### PR TITLE
Upscale source frames to fill the panel

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -100,13 +100,28 @@ static void InterruptHandler(int) {
 
 static void DrawFrame(FrameCanvas *canvas, const uint8_t *frame_data, int width,
                       int height) {
-  int max_x = std::min(width, canvas->width());
-  int max_y = std::min(height, canvas->height());
-  for (int y = 0; y < max_y; ++y) {
-    for (int x = 0; x < max_x; ++x) {
-      int index = (y * width + x) * 4;  // RGBA
-      canvas->SetPixel(x, y, frame_data[index], frame_data[index + 1],
-                       frame_data[index + 2]);
+  const int canvas_w = canvas->width();
+  const int canvas_h = canvas->height();
+  // Integer nearest-neighbor upscale when the panel is larger than the source
+  // frame (e.g. server sends 64x32 to a 128x64 FM6353 panel). Centered. When
+  // the source is larger than the panel we fall through to scale=1 and clip
+  // top-left, matching the legacy behavior.
+  int scale = 1;
+  if (width > 0 && height > 0) {
+    scale = std::min(canvas_w / width, canvas_h / height);
+    if (scale < 1) scale = 1;
+  }
+  const int draw_w = std::min(width * scale, canvas_w);
+  const int draw_h = std::min(height * scale, canvas_h);
+  const int offset_x = (canvas_w - draw_w) / 2;
+  const int offset_y = (canvas_h - draw_h) / 2;
+  for (int y = 0; y < draw_h; ++y) {
+    const int src_y = y / scale;
+    for (int x = 0; x < draw_w; ++x) {
+      const int src_x = x / scale;
+      const int index = (src_y * width + src_x) * 4;  // RGBA
+      canvas->SetPixel(offset_x + x, offset_y + y, frame_data[index],
+                       frame_data[index + 1], frame_data[index + 2]);
     }
   }
 }


### PR DESCRIPTION
Context — I am running tronberry on a 128x64 HUB75 panel driven by FM6353 chips, where the server still sends 64x32 frames. Out of the box the image fills only the top-left quarter of the panel and the rest stays dark.

The underlying display driver work (FM6353 support in rpi-rgb-led-matrix_pwm_experiment) is in flight as a separate PR against kingdo9 fork: https://github.com/kingdo9/rpi-rgb-led-matrix_pwm_experiment/pull/5

Ideally that lands and propagates up to hzeller/rpi-rgb-led-matrix eventually, but this tronberry change is independent of it — it just makes DrawFrame respect the actual panel canvas size for any 2x/3x/... bigger panel, not specifically FM6353.

## What changes

DrawFrame used to clip the source frame to the canvas: a 64x32 frame on a 128x64 panel painted the top-left 64x32 and left the rest untouched. Now it picks the largest integer scale that fits the source into the canvas in both axes and renders nearest-neighbor, centered. If the source is larger than the panel we fall back to scale=1 with top-left clipping — i.e. the same behavior as before, so existing 64x32-panel setups are untouched.

PR #16 fixed the source-larger-than-panel side of this same mismatch (out-of-bounds SetPixel); this is the missing other half.

## Test plan

- 128x64 FM6353 panel with --led-rows=64 --led-cols=128: 64x32 frames now fill the whole panel at 2x.
- 64x32 panel setup: scale=1, behavior unchanged.

## Thanks

- @IngmarStein for keeping tronberry actively maintained and PR-friendly.
- @kingdo9 for the SPWM PWM-experiment fork of rpi-rgb-led-matrix that made FM6353 feasible to add.
- @board707 (Dmitry Dmitriev) whose DMD_STM32 library provided the FM6353 protocol values and timing reference used in the kingdo9 PR.